### PR TITLE
Update search logic for retrieving more advocates

### DIFF
--- a/src/app/api/advocates/search/route.ts
+++ b/src/app/api/advocates/search/route.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, gt, like, sql } from "drizzle-orm";
+import { and, asc, count, desc, gt, like, sql } from "drizzle-orm";
 import db from "../../../../db";
 import { advocates } from "../../../../db/schema";
 import { NextRequest } from "next/server";
@@ -38,16 +38,20 @@ export async function POST(request: NextRequest) {
     )
     .limit(pageSize)
     .orderBy(asc(advocates.id));
+  const advocateCursor = data.slice(-1)[0];
 
-  const advocateCountData = await db.select({ count: count() }).from(advocates);
-  const advocateCount = advocateCountData[0].count;
-
-  const lastItem = data.slice(-1)[0];
+  const lastAdvocateData = await db
+    .select({ last: advocates.id })
+    .from(advocates)
+    .where(like(field, `%${searchTerm.toLowerCase()}%`))
+    .limit(1)
+    .orderBy(desc(advocates.id));
+  const lastId = lastAdvocateData[0].last;
 
   return Response.json({
     data,
-    cursor: lastItem.id,
-    count: advocateCount,
+    cursor: advocateCursor.id,
+    count: lastId,
     body: request.json(),
   });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -113,7 +113,6 @@ export default function Home() {
             setSearchCriteria(searchCriteria);
             setSearchTerm(searchTerm);
 
-            setCursor(nextCursor);
             setNextCursor(jsonResponse.cursor);
             setCount(jsonResponse.count);
           })
@@ -162,12 +161,10 @@ export default function Home() {
 
   const loadPreviousAdvocates = () => {
     const newCursor = cursor - PAGE_SIZE >= 0 ? cursor - PAGE_SIZE : 0;
-    if (!searchActive) {
-      setCursor(newCursor);
-    }
+    setCursor(newCursor);
 
     searchActive
-      ? searchAdvocates(searchCriteria, searchTerm, cursor)
+      ? searchAdvocates(searchCriteria, searchTerm, newCursor)
       : fetchAdvocates(newCursor);
   };
 


### PR DESCRIPTION
- Change count to id of last advocate matching search result
- Remove extraneous logic from searching advocates
- KNOWN ISSUE: There's no easy way to search previous advocates through pagination without switching to a framework that natively supports cursors and pagination